### PR TITLE
#8-fixes-update-to-support-ansible-2-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Please see ToDo (below). Will add a bunch of stuff continously
 
 
 ````
+Versions Installed in boxes right now (will always fetch latest):
+
+CentOS 7.1 
+Docker version 1.9.1, build a34a1d5
+pip (7.1.2)
+six (1.10.0)
+setuptools (0.9.8)
+docker-py (1.6.0)
+
+
 Current machine states:
 
 dockerhost-01.example.com  [ Docker Engine ]
@@ -25,7 +35,11 @@ consul-01.example.com  [ Consul server + Memory, CPU, HDD checks + Docker Engine
 consul-02.example.com  [ Consul server + Memory, CPU, HDD checks + Docker Engine ]
 consul-03.example.com  [ Consul server + Memory, CPU, HDD checks + Docker Engine ]
 ```
+# Requirements
 
+Ansible 2.1.x
+Vagrant 1.8.x
+Virtualbox v.5.x
 
 # Structure
 Currently this is a work in progress and I will commit, rewrite the code, commit some more, change the architechture around, use some different products like Mesos for example. Nothing is set in stone just yet.
@@ -38,11 +52,13 @@ $ tree
 ├── LICENSE
 ├── README.md
 ├── Vagrantfile
-├── nodes.json
+├── architecture
+│   └── architecture.jpg
 └── provisioning
     ├── consul.yml
     ├── dnsmasq.yml
     ├── docker.yml
+    ├── dockerswarm.yml
     ├── hosts
     ├── roles
     │   ├── common
@@ -69,21 +85,26 @@ $ tree
     │   │   │   └── main.yml
     │   │   └── templates
     │   │       └── 10-consul.conf
-    │   └── docker
-    │       ├── defaults
-    │       │   └── main.yml
-    │       ├── files
-    │       │   └── override.conf
-    │       ├── handlers
-    │       │   └── main.yml
-    │       ├── tasks
-    │       │   └── main.yml
-    │       ├── templates
-    │       │   ├── docker-main.repo.j2
-    │       │   └── sysconfig.j2
-    │       └── vars
+    │   ├── docker
+    │   │   ├── defaults
+    │   │   │   └── main.yml
+    │   │   ├── files
+    │   │   │   └── override.conf
+    │   │   ├── handlers
+    │   │   │   └── main.yml
+    │   │   ├── tasks
+    │   │   │   └── main.yml
+    │   │   ├── templates
+    │   │   │   ├── docker-main.repo.j2
+    │   │   │   └── sysconfig.j2
+    │   │   └── vars
+    │   │       └── main.yml
+    │   └── dockerswarm
+    │       └── tasks
     │           └── main.yml
     └── site.yml
+
+24 directories, 30 files
 
 ````
 # ToDo

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,8 +25,8 @@ groups = {
     "#{engine_name}" => [], 
     "#{cluster_name}" => [],
     "#{discovery_name}" => [],
-    "#{discovery_name}:master" => ["#{discovery_name}-01.#{domainname}"],
-    "#{discovery_name}:server" => ["#{discovery_name}-02.#{domainname}", "#{discovery_name}-03.#{domainname}"],
+    "#{discovery_name}_master" => ["#{discovery_name}-01.#{domainname}"],
+    "#{discovery_name}_server" => ["#{discovery_name}-02.#{domainname}", "#{discovery_name}-03.#{domainname}"],
     "all:children" => ["#{engine_name}","#{cluster_name}","#{discovery_name}"], 
     }
 
@@ -99,17 +99,24 @@ Vagrant.configure(2) do |config|
             pv.groups = groups
             pv.sudo = true
             pv.extra_vars = ansible_vars
-            #pv.verbose = 'vvvv'
+            pv.verbose = 'vvvv'
       end
+
+      # #8 - Update to support ansible 2.x
+      # this provisioner is not being used any more
+      # in favor for running the docker modules
+      # that will manage containers inside the tasks instead
+      # as a playbook.
+      #
       # Runs a provisioner 
-      if provisioner == "docker"
-           config.vm.provision "docker", run: run do |pv|
-             pv.pull_images image
-             pv.run image,
-             cmd: docker_cmd,
-             args: docker_args 
-           end
-      end
+#      if provisioner == "docker"
+#           config.vm.provision "docker", run: run do |pv|
+#             pv.pull_images image
+#             pv.run image,
+#            cmd: docker_cmd,
+#             args: docker_args 
+#           end
+#     end
     end
   end
 end

--- a/provisioning/consul.yml
+++ b/provisioning/consul.yml
@@ -2,4 +2,4 @@
 - hosts: consul
   remote_user: vagrant
   roles:
-  - { role: consul, sudo: yes }
+    - { role: consul, become: yes, become_method: sudo }

--- a/provisioning/dnsmasq.yml
+++ b/provisioning/dnsmasq.yml
@@ -2,4 +2,4 @@
 - hosts: consul-01.example.com
   remote_user: vagrant
   roles:
-  - { role: dnsmasq, sudo: yes }
+    - { role: dnsmasq, become: yes, become_method: sudo }

--- a/provisioning/docker.yml
+++ b/provisioning/docker.yml
@@ -2,5 +2,5 @@
 - hosts: dockerhost
   remote_user: vagrant
   roles:
-  - { role: consul, sudo: yes }
-  - { role: docker, sudo: yes }
+  - { role: consul }
+  - { role: docker }

--- a/provisioning/dockerswarm.yml
+++ b/provisioning/dockerswarm.yml
@@ -1,0 +1,7 @@
+---
+- hosts: dockerswarm
+  remote_user: vagrant
+  roles:
+  - { role: consul }
+  - { role: docker }
+  - { role: dockerswarm, become: yes, become_method: sudo }

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -1,8 +1,16 @@
 ---
-
 - name: Install os packages
   yum: name={{item}} state=present
   with_items:
   - unzip
   - bc
   - net-tools
+  - vim
+  - python-devel
+  - python-setuptools
+
+- name: Download pip.
+  get_url: url=https://bootstrap.pypa.io/get-pip.py dest=/tmp
+
+- name: Install pip.
+  command: "python /tmp/get-pip.py"

--- a/provisioning/roles/docker/tasks/main.yml
+++ b/provisioning/roles/docker/tasks/main.yml
@@ -27,3 +27,9 @@
   template:
     src: sysconfig.j2
     dest: /etc/sysconfig/docker
+
+- name: Install six
+  pip: name=six
+
+- name: Install Docker-Py
+  pip: name=docker-py

--- a/provisioning/roles/dockerswarm/tasks/main.yml
+++ b/provisioning/roles/dockerswarm/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Swarm create
+  docker:
+    name: swarm_cluster
+    image: swarm
+#   pull: always
+    state: present
+#   command: create
+  #register: cluster_id

--- a/provisioning/site.yml
+++ b/provisioning/site.yml
@@ -1,4 +1,10 @@
 ---
+- hosts: all
+  remote_user: vagrant
+  roles:
+    - { role: common, become: yes, become_method: sudo }
+
 - include: consul.yml 
 - include: dnsmasq.yml 
 - include: docker.yml 
+- include: dockerswarm.yml 


### PR DESCRIPTION
Added dockerswarm docker container inside new role for swarm, added support for ansible 2.x by changing the deprecated sudo: yes to become: yes, become_method: sudo instead. Added some default pip packages to common role and update Readme and Vagrantfile'
[fixes-8-update-to-support-ansible-2-x 96c15d8] #8-fixes-update-to-support-ansible-2-x: Added dockerswarm docker container inside new role for swarm, added support for ansible 2.x by changing the deprecated sudo: yes to become: yes, become_method: sudo instead. Added some default pip packages to common role and update Readme and Vagrantfile
