### PR TITLE
Bug #20 ansible fails downloading consul from the hashicorp path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip (7.1.2)
 six (1.10.0)
 setuptools (0.9.8)
 docker-py (1.6.0)
-consul (0.6.3)
+consul (0.6.4)
 
 Current machine states:
 
@@ -62,8 +62,7 @@ $ tree
     ├── roles
     │   ├── common
     │   │   └── tasks
-    │   │       ├── main.yml
-    │   │       └── userinfo.yml
+    │   │       └── main.yml
     │   ├── consul
     │   │   ├── defaults
     │   │   │   └── main.yml
@@ -110,6 +109,9 @@ $ tree
     │   │       ├── agent.yml
     │   │       ├── main.yml
     │   │       └── manager.yml
+    │   ├── final
+    │   │   └── tasks
+    │   │       └── main.yml
     │   ├── registrator
     │   │   └── tasks
     │   │       └── main.yml
@@ -120,8 +122,7 @@ $ tree
     │           └── main.yml
     └── site.yml
 
-28 directories, 39 files
-
+30 directories, 39 files
 ````
 # ToDo
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,10 +14,11 @@ nodes = [
   { :hostname => "#{discovery_name}-01.#{domainname}", :ip => "192.168.35.101" },
   { :hostname => "#{discovery_name}-02.#{domainname}", :ip => "192.168.35.102" },
   { :hostname => "#{discovery_name}-03.#{domainname}", :ip => "192.168.35.103" },
+  { :hostname => "#{manager_name}-01.#{domainname}", :ip => "192.168.35.124"},
   { :hostname => "#{agent_name}-01.#{domainname}", :ip => "192.168.35.121" },
   { :hostname => "#{agent_name}-02.#{domainname}", :ip => "192.168.35.122" },
   { :hostname => "#{agent_name}-03.#{domainname}", :ip => "192.168.35.123" },
-  { :hostname => "#{manager_name}-01.#{domainname}", :ip => "192.168.35.124"},
+
 
 ]
 

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -15,6 +15,3 @@
 
 - name: Install pip.
   command: "python /tmp/get-pip.py"
-
-- include: userinfo.yml
-  when: swarm.master_name in ansible_fqdn

--- a/provisioning/roles/consul/defaults/main.yml
+++ b/provisioning/roles/consul/defaults/main.yml
@@ -1,6 +1,6 @@
-consul_installer_url_base: https://releases.hashicorp.com/consul
-consul_installer_filename: "consul_{{ consul_version }}.zip"
-consul_version: 0.6.3
+consul_installer_url_base: "https://releases.hashicorp.com/consul/{{consul_version}}"
+consul_installer_filename: "consul_{{ consul_version }}_linux_amd64.zip"
+consul_version: 0.6.4
 consul_install_dir: /opt/consul
 consul_log_level: INFO
 

--- a/provisioning/roles/consul/tasks/install.yml
+++ b/provisioning/roles/consul/tasks/install.yml
@@ -1,10 +1,4 @@
 ---
-- name: Install os packages
-  yum: name={{item}} state=present
-  with_items:
-  - unzip
-  - bc
-
 - name: Add Consul User
   user: name=consul state=present home={{ consul_install_dir}}
 
@@ -30,12 +24,12 @@
 
 - name: Download Consul WebUI
   get_url: url={{ consul_installer_url_base }}/{{consul_web_ui_installer_filename}} dest={{consul_install_dir}}/{{consul_web_ui_installer_filename}}
-  when: ansible_eth1.ipv4.address == "192.168.35.101"
+  when: ansible_eth1.ipv4.address == common.master_ip
 
 - name: Unarchive Consul WebUI
   unarchive: copy=no src={{consul_install_dir}}/{{ consul_web_ui_installer_filename }} dest={{ consul_ui_install_dir }} owner=consul group=root mode=0755
   register: consul_UI_installed
-  when: ansible_eth1.ipv4.address == "192.168.35.101"
+  when: ansible_eth1.ipv4.address == common.master_ip
   notify:
   - restart systemd
   - restart consul

--- a/provisioning/roles/final/tasks/main.yml
+++ b/provisioning/roles/final/tasks/main.yml
@@ -6,4 +6,3 @@
    - { name: 'Consul UI', url: "{{ common.master_ip }}" }
    - { name: 'ShipYard UI', url: "{{ swarm.master_ip }}:8080" }
   tags: userinfo
-

--- a/provisioning/site.yml
+++ b/provisioning/site.yml
@@ -1,13 +1,9 @@
 ---
-- hosts: consul
-  remote_user: vagrant
-  roles:
-    - { role: consul, become: yes, become_method: sudo }
-
 - hosts: all
   remote_user: vagrant
   roles:
     - { role: common, become: yes, become_method: sudo }
+    - { role: consul, become: yes, become_method: sudo }
     - { role: dnsmasq, become: yes, become_method: sudo }
     - { role: docker, become: yes, become_method: sudo }
     - { role: registrator, become: yes, become_method: sudo }
@@ -17,4 +13,4 @@
   remote_user: vagrant
   roles:
     - { role: shipyard, become: yes, become_method: sudo }
-    - { role: common, become: yes, become_method: sudo, tags: userinfo }
+    - { role: final, become: yes, become_method: sudo, tags: userinfo }


### PR DESCRIPTION
Fixes #20 by updating the path for hashicorps consul and updating to use 0.6.4 version of consul
