### PR TITLE
Add a second swarm manager as a replica #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ consul-01.example.com  [ Consul server + Memory, CPU, HDD checks + Docker Engine
 consul-02.example.com  [ Consul server + Memory, CPU, HDD checks + Docker Engine + Registrator + Docker compose ]
 consul-03.example.com  [ Consul server + Memory, CPU, HDD checks + Docker Engine + Registrator + Docker compose ]
 Dockerswarm-01.example.com [ Docker Engine + Registrator + Swarm manager + Shipyard UI + Docker compose ]
+Dockerswarm-02.example.com [ Docker Engine + Registrator + Swarm manager replication + Shipyard UI + Docker compose ]
 swarmnode-01.example.com  [ Docker Engine + Registrator + Swarm agent + Docker Compose ]
 swarmnode-02.example.com  [ Docker Engine + Registrator + Swarm agent + Docker Compose ]
 swarmnode-03.example.com  [ Docker Engine + Registrator + Swarm agent + Docker Compose ]
@@ -114,7 +115,8 @@ $ tree
     │   │   └── tasks
     │   │       ├── agent.yml
     │   │       ├── main.yml
-    │   │       └── manager.yml
+    │   │       ├── manager.yml
+    │   │       └── replica.yml
     │   ├── final
     │   │   └── tasks
     │   │       └── main.yml
@@ -128,15 +130,20 @@ $ tree
     │           └── main.yml
     └── site.yml
 
-32 directories, 41 files
+32 directories, 42 files
+
 ````
 # ToDo
 
-Add registry or Artifactory as a Docker registry.
+Update to use docker overlay network #19
 
-Update to use Docker Network overlay
+Add TLS for communication #24
 
-Change to high availability Swarm manager with replicas and fail-over
+Add a second swarm manager as a replica enhancement #27
+
+Add registry or artifactory as a Docker registry #28
+
+Add support for container metrics / Data / monitoring / alerts #29
 
 # How to 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ nodes = [
   { :hostname => "#{discovery_name}-02.#{domainname}", :ip => "192.168.35.102" },
   { :hostname => "#{discovery_name}-03.#{domainname}", :ip => "192.168.35.103" },
   { :hostname => "#{manager_name}-01.#{domainname}", :ip => "192.168.35.124"},
+  { :hostname => "#{manager_name}-02.#{domainname}", :ip => "192.168.35.125"},
   { :hostname => "#{agent_name}-01.#{domainname}", :ip => "192.168.35.121" },
   { :hostname => "#{agent_name}-02.#{domainname}", :ip => "192.168.35.122" },
   { :hostname => "#{agent_name}-03.#{domainname}", :ip => "192.168.35.123" },
@@ -75,6 +76,7 @@ Vagrant.configure(2) do |config|
     },
     :swarm => {
       :master_name => "#{manager_name}-01.#{domainname}",
+      :replica_name => "#{manager_name}-02.#{domainname}",
       :master_ip => "192.168.35.124",
       :agent_name => "#{agent_name}",
       :strategy => "spread",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,9 +96,8 @@ Vagrant.configure(2) do |config|
       config.vm.box = box
       config.vm.hostname = hostname
       config.vm.network :private_network, ip: ip
-      config.vm.boot_timeout = 800
-      config.ssh.insert_key = false
-
+      #config.vm.boot_timeout = 800
+      #config.ssh.insert_key = true
       config.vm.provider :virtualbox do |vb|
         vb.customize ["modifyvm", :id, "--memory", memory, "--name", hostname]
       end

--- a/provisioning/roles/dockerswarm/tasks/agent.yml
+++ b/provisioning/roles/dockerswarm/tasks/agent.yml
@@ -4,4 +4,4 @@
     name: swarm-agent
     image: swarm
     state: restarted
-    command: join --advertise="{{ ansible_eth1.ipv4.address}}":2375 consul://"{{common.master_ip}}"/swarm
+    command: join --advertise="{{ ansible_eth1.ipv4.address}}":2375 consul://"{{common.master_ip}}"/

--- a/provisioning/roles/dockerswarm/tasks/agent.yml
+++ b/provisioning/roles/dockerswarm/tasks/agent.yml
@@ -3,5 +3,5 @@
   docker:
     name: swarm-agent
     image: swarm
-    state: restarted
+    state: reloaded
     command: join --advertise="{{ ansible_eth1.ipv4.address}}":2375 consul://"{{common.master_ip}}"/

--- a/provisioning/roles/dockerswarm/tasks/main.yml
+++ b/provisioning/roles/dockerswarm/tasks/main.yml
@@ -3,6 +3,11 @@
   include: manager.yml
   when: ansible_fqdn in swarm.master_name 
 
+- name: Swarm manager replica task
+  include: replica.yml
+  when: ansible_fqdn in swarm.replica_name 
+
+
 - name: Swarm agent task
   include: agent.yml
   when: swarm.agent_name in ansible_fqdn

--- a/provisioning/roles/dockerswarm/tasks/manager.yml
+++ b/provisioning/roles/dockerswarm/tasks/manager.yml
@@ -7,5 +7,5 @@
     pull: always
     publish_all_ports: true
     ports:
-      - "3375:3375"
-    command: manage -H tcp://0.0.0.0:3375 --strategy "{{swarm.strategy}}" consul://"{{common.master_ip}}"/swarm
+      - "3375:2375"
+    command: manage --strategy "{{swarm.strategy}}" consul://"{{common.master_ip}}"/

--- a/provisioning/roles/dockerswarm/tasks/replica.yml
+++ b/provisioning/roles/dockerswarm/tasks/replica.yml
@@ -1,5 +1,5 @@
 ---
-- name: Swarm manager
+- name: Swarm manager replica
   docker:
     image: swarm
     name: swarm-manager
@@ -9,4 +9,4 @@
     restart_policy: unless-stopped
     ports:
       - "3375:2375"
-    command: manage --strategy "{{swarm.strategy}}" consul://"{{common.master_ip}}"/
+    command: manage --strategy "{{swarm.strategy}}" --advertise="{{ ansible_eth1.ipv4.address}}":3375 --replication consul://"{{common.master_ip}}"/

--- a/provisioning/roles/final/tasks/main.yml
+++ b/provisioning/roles/final/tasks/main.yml
@@ -4,5 +4,5 @@
     msg: "Provisioning completed: {{ item.name }}: http://{{ item.url }}"
   with_items:
    - { name: 'Consul UI', url: "{{ common.master_ip }}" }
-   - { name: 'ShipYard UI', url: "{{ swarm.master_ip }}:8080" }
+   - { name: 'ShipYard UI', url: "{{ ansible_eth1.ipv4.address }}:8080" }
   tags: userinfo

--- a/provisioning/roles/shipyard/tasks/controller.yml
+++ b/provisioning/roles/shipyard/tasks/controller.yml
@@ -11,4 +11,4 @@
     - "swarm-manager:swarm"
     ports:
     - "8080:8080"
-    command: server -d tcp://swarm:3375
+    command: server -d tcp://"{{ ansible_eth1.ipv4.address}}":3375


### PR DESCRIPTION
Fixes #27 : Add-a-second-swarm-manager-as-a-replica-#27: Updated Readme, added the new ansible role for dockerswarm replication, updated the shipyard task and final task to reflect the change
